### PR TITLE
BFX-400 Add Self Checkout Status

### DIFF
--- a/lib/sip2.rb
+++ b/lib/sip2.rb
@@ -3,10 +3,12 @@ require 'sip2/version'
 require 'sip2/responses/base_response'
 require 'sip2/responses/patron_information'
 require 'sip2/responses/patron_status'
+require 'sip2/responses/self_checkout_status'
 
 require 'sip2/messages/login'
 require 'sip2/messages/patron_information'
 require 'sip2/messages/patron_status'
+require 'sip2/messages/self_checkout_status'
 
 require 'sip2/non_blocking_socket'
 require 'sip2/connection'

--- a/lib/sip2/connection.rb
+++ b/lib/sip2/connection.rb
@@ -16,6 +16,7 @@ module Sip2
     include Messages::Login
     include Messages::PatronInformation
     include Messages::PatronStatus
+    include Messages::SelfCheckoutStatus
 
     def initialize(socket, ignore_error_detection)
       @socket = socket

--- a/lib/sip2/messages/self_checkout_status.rb
+++ b/lib/sip2/messages/self_checkout_status.rb
@@ -1,0 +1,33 @@
+module Sip2
+  module Messages
+    #
+    # Sip2 Patron Status message module
+    #
+    # https://developers.exlibrisgroup.com/alma/integrations/selfcheck/sip2
+    #
+    # Self Checkout status (99)
+    # Output message: 9909992.00
+    #
+    module SelfCheckoutStatus
+      def self.included(klass)
+        klass.add_connection_module :self_checkout_status
+      end
+
+      private
+
+      def build_self_checkout_status_message
+        code = '99' # Self Checkout status
+        status_code = '0' # SC unit is okay
+        max_print_width = '999' # Terminal width (required, but we don't care)
+        protocol_version = '2.00' # SIP2 version
+
+        code + status_code + max_print_width + protocol_version
+      end
+
+      def handle_self_checkout_status_response(response)
+        return unless sequence_and_checksum_valid?(response)
+        Sip2::Responses::SelfCheckoutStatus.new response
+      end
+    end
+  end
+end

--- a/lib/sip2/responses/base_response.rb
+++ b/lib/sip2/responses/base_response.rb
@@ -10,7 +10,10 @@ module Sip2
       @@response_objects = {}
 
       def initialize(raw_response)
-        @raw_response = raw_response.strip
+        @raw_response = raw_response&.strip
+        if @raw_response.nil? || @raw_response.empty?
+          raise ArgumentError, 'raw_response from SIP2 server cannot be blank'
+        end
       end
 
       # Look up the proepr response class for the given response

--- a/lib/sip2/responses/base_response.rb
+++ b/lib/sip2/responses/base_response.rb
@@ -50,9 +50,9 @@ module Sip2
         end
       end
 
-      # Retrieve a numeric value of known length from the response.
+      # Retrieve an integer value of known length from the response.
       def numeric(position, length)
-        raw_response[position + 2, length]
+        raw_response[position + 2, length].to_i
       end
 
       # Retrieve a boolean value from the response.

--- a/lib/sip2/responses/base_response.rb
+++ b/lib/sip2/responses/base_response.rb
@@ -4,6 +4,8 @@ module Sip2
     # text and boolean fields from the response.
     #
     class BaseResponse
+      class EmptyResponseException < StandardError
+      end
       attr_reader :raw_response
 
       # rubocop:disable Style/ClassVars
@@ -11,9 +13,9 @@ module Sip2
 
       def initialize(raw_response)
         @raw_response = raw_response&.strip
-        if @raw_response.nil? || @raw_response.empty?
-          raise ArgumentError, 'raw_response from SIP2 server cannot be blank'
-        end
+        return unless @raw_response.nil? || @raw_response.empty?
+
+        raise EmptyResponseException, 'raw_response from SIP2 server cannot be blank'
       end
 
       # Look up the proepr response class for the given response

--- a/lib/sip2/responses/base_response.rb
+++ b/lib/sip2/responses/base_response.rb
@@ -37,8 +37,17 @@ module Sip2
       private
 
       # Retrieve a text string from the response.
-      def text(message_id)
-        parse_text(raw_response, message_id)
+      def text(message_id, length = nil)
+        if message_id.is_a?(Numeric)
+          parse_positional_text(raw_response, message_id, length)
+        else
+          parse_text(raw_response, message_id)
+        end
+      end
+
+      # Retrieve a numeric value of known length from the response.
+      def numeric(position, length)
+        raw_response[position + 2, length]
       end
 
       # Retrieve a boolean value from the response.
@@ -61,7 +70,11 @@ module Sip2
       end
 
       def parse_text(response, message_id)
-        response[/\|#{message_id}(.*?)\|/, 1]
+        response[/\|?#{message_id}(.*?)\|/, 1]
+      end
+
+      def parse_positional_text(response, position, length)
+        response[position + 2, length]
       end
 
       def parse_positional_argument(response, position)

--- a/lib/sip2/responses/self_checkout_status.rb
+++ b/lib/sip2/responses/self_checkout_status.rb
@@ -1,0 +1,116 @@
+module Sip2
+  module Responses
+    #
+    # Sip2 Patron Status Response
+    #
+    # Self checkout status response (98)
+    #
+    # 98YYYYNN99999920101014    1158092.00AOMAIN|BXYYYNYYYYNNNNNYYN|AY0AZEDE3
+    #
+    # Message Fixed-width Positional Attributes in order from left to right:
+    # 
+    # 98                    - the message identifier.
+    # YYYYNN                - status flags for online_status, check_in_ok, check_out_ok, renewal_policy, status_update_ok, and offline_ok.
+    # 999                   - timeout period
+    # 999                   - number of retries allowed.
+    # 20101014    115809    - the datetime offset.
+    # 2.00                  - the SIP version targeted.
+    #
+    # Other fields are indexed by keys:
+    #
+    # institutionId      AO - the institution ID. e.g. MAIN
+    #
+    # supportedMessages |BX| In character position order:
+    #   - Patron Status Request (23)
+    #   - Checkout (11)
+    #   - Checkin (09)
+    #   - Block Patron (01)
+    #   - SC/ACS Status (99)
+    #   - Request SC/ACS Resend (97)
+    #   - Login (93)
+    #   - Patron Information (63)
+    #   - End Patron Session (35)
+    #   - Fee Paid (37)
+    #   - Item Information (17)
+    #   - Item Status Update (19)
+    #   - Patron Enable (25)
+    #   - Hold (15)
+    #   - Renew (29)
+    #   - Renew All (65)
+    #
+    class SelfCheckoutStatus < BaseResponse
+      register_response_code 98
+
+      def online_status?
+        boolean 0
+      end
+
+      def check_in_ok?
+        boolean 1
+      end
+
+      def check_out_ok?
+        boolean 2
+      end
+
+      def renewal_policy?
+        boolean 3
+      end
+
+      def status_update_ok?
+        boolean 4
+      end
+
+      def offline_ok?
+        boolean 5
+      end
+
+      def timeout_period
+        numeric 6, 3
+      end
+
+      def retries_allowed
+        numeric 9, 3
+      end
+
+      # This is not a properly formatted datetime.
+      def date_time_sync
+        text 12, 18
+      end
+
+      # Expected to be "2.00"
+      def version
+        text 30, 4
+      end
+
+      def institution_id
+        text 'AO'
+      end
+
+      def library_name
+        text 'AM'
+      end
+
+      # This could be parsed further to provide more customized SIP2 integrations
+      def supported_messages
+        text 'BX'
+      end
+
+      def screen_message
+        text 'AF'
+      end
+
+      def print_line
+        text 'AG'
+      end
+
+      private
+
+      def attributes_for_inspect
+        %i[fee_amount personal_name valid_patron? valid_patron_password? 
+           excessive_fines_or_fees? charge_privileges_denied? 
+           renewal_privileges_denied? screen_message]
+      end
+    end
+  end
+end

--- a/spec/responses/base_response_spec.rb
+++ b/spec/responses/base_response_spec.rb
@@ -10,7 +10,7 @@ describe Sip2::Responses::BaseResponse do
     let(:raw_response) { '   ' }
 
     it 'raises an ArgumentError' do
-      expect { response_object }.to raise_error(ArgumentError)
+      expect { response_object }.to raise_error(described_class::EmptyResponseException)
     end
   end
 
@@ -18,7 +18,7 @@ describe Sip2::Responses::BaseResponse do
     let(:raw_response) { nil }
 
     it 'raises an ArgumentError' do
-      expect { response_object }.to raise_error(ArgumentError)
+      expect { response_object }.to raise_error(described_class::EmptyResponseException)
     end
   end
 

--- a/spec/responses/base_response_spec.rb
+++ b/spec/responses/base_response_spec.rb
@@ -6,6 +6,22 @@ describe Sip2::Responses::BaseResponse do
   let(:raw_response) { '24 Y            00020101014    120240|BHGBP|BLY|CQN|AAJSMITH|AESmith, John|BV15.00|AY0AZE4FD' }
   # rubocop:enable LineLength
 
+  context 'when given a blank raw_response' do
+    let(:raw_response) { '   ' }
+
+    it 'raises an ArgumentError' do
+      expect { response_object }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'when given a nil raw_response' do
+    let(:raw_response) { nil }
+
+    it 'raises an ArgumentError' do
+      expect { response_object }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#text' do
     subject { response_object.send(:text, code) }
 

--- a/spec/responses/patron_information_spec.rb
+++ b/spec/responses/patron_information_spec.rb
@@ -20,11 +20,6 @@ describe Sip2::Responses::PatronInformation do
       let(:response) { raw_response_invalid_patron }
       it { is_expected.to be_falsey }
     end
-
-    context 'invalid response' do
-      let(:response) { invalid_response }
-      it { is_expected.to be_falsey }
-    end
   end
 
   describe 'authenticated?' do
@@ -35,11 +30,6 @@ describe Sip2::Responses::PatronInformation do
 
     context 'false response' do
       let(:response) { raw_response_incorrect_barcode }
-      it { is_expected.to be_falsey }
-    end
-
-    context 'invalid response' do
-      let(:response) { invalid_response }
       it { is_expected.to be_falsey }
     end
   end
@@ -70,11 +60,6 @@ describe Sip2::Responses::PatronInformation do
     context 'blank response' do
       let(:response) { 'FOO|AQ|BAR' }
       it { is_expected.to eq '' }
-    end
-
-    context 'no location information' do
-      let(:response) { invalid_response }
-      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/responses/patron_status_spec.rb
+++ b/spec/responses/patron_status_spec.rb
@@ -26,11 +26,6 @@ describe Sip2::Responses::PatronStatus do
       it { is_expected.to be true }
     end
 
-    context 'invalid response' do
-      let(:response) { invalid_response }
-      it { is_expected.to be false }
-    end
-
     context 'Kona - Real message' do
       let(:response) { "\n24YYYY      YY  00020201228    100524AEFines test8|AA21906009136618|BLY|CQN|BV140|AFGreetings from Koha.  -- Patron owes 140.00|AO|AY2AZDA5A" }
       it { is_expected.to be true }
@@ -48,11 +43,6 @@ describe Sip2::Responses::PatronStatus do
     context 'with a card with revoked charge privileges' do
       let(:response) { raw_response_card_renewal_denied }
       it { is_expected.to be true }
-    end
-
-    context 'invalid response' do
-      let(:response) { invalid_response }
-      it { is_expected.to be false }
     end
   end
 
@@ -72,11 +62,6 @@ describe Sip2::Responses::PatronStatus do
     context 'with outstanding fines' do
       let(:response) { raw_response_outstanding_fines }
       it { is_expected.to be true }
-    end
-
-    context 'invalid response' do
-      let(:response) { invalid_response }
-      it { is_expected.to be false }
     end
   end
 

--- a/spec/responses/self_checkout_status_spec.rb
+++ b/spec/responses/self_checkout_status_spec.rb
@@ -46,13 +46,13 @@ describe Sip2::Responses::SelfCheckoutStatus do
   describe '#timeout_period' do
     subject { self_checkout_status.timeout_period }
 
-    it { is_expected.to eq('999') }
+    it { is_expected.to eq(999) }
   end
 
   describe '#retries_allowed' do
     subject { self_checkout_status.retries_allowed }
 
-    it { is_expected.to eq('999') }
+    it { is_expected.to eq(999) }
   end
 
   describe '#date_time_sync' do

--- a/spec/responses/self_checkout_status_spec.rb
+++ b/spec/responses/self_checkout_status_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Sip2::Responses::SelfCheckoutStatus do
+  let(:self_checkout_status) { Sip2::Responses::SelfCheckoutStatus.new response }
+
+  # rubocop:disable LineLength
+  let(:response) { '98YYYYNN99999920101014    1158092.00AOMAIN|BXYYYNYYYYNNNNNYYN|AY0AZEDE3' }
+  # rubocop:enable LineLength
+
+  describe '#online_status?' do
+    subject { self_checkout_status.online_status? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#check_in_ok?' do
+    subject { self_checkout_status.check_in_ok? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#check_out_ok?' do
+    subject { self_checkout_status.check_out_ok? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#renewal_policy?' do
+    subject { self_checkout_status.renewal_policy? }
+
+    it { is_expected.to be true }
+  end
+
+  describe '#status_update_ok?' do
+    subject { self_checkout_status.status_update_ok? }
+
+    it { is_expected.to be false }
+  end
+
+  describe '#offline_ok?' do
+    subject { self_checkout_status.offline_ok? }
+
+    it { is_expected.to be false }
+  end
+
+  describe '#timeout_period' do
+    subject { self_checkout_status.timeout_period }
+
+    it { is_expected.to eq('999') }
+  end
+
+  describe '#retries_allowed' do
+    subject { self_checkout_status.retries_allowed }
+
+    it { is_expected.to eq('999') }
+  end
+
+  describe '#date_time_sync' do
+    subject { self_checkout_status.date_time_sync }
+
+    it { is_expected.to eq('20101014    115809') }
+  end
+
+  describe '#version' do
+    subject { self_checkout_status.version }
+
+    it { is_expected.to eq('2.00') }
+  end
+
+  describe '#institution_id' do
+    subject { self_checkout_status.institution_id }
+
+    it { is_expected.to eq('MAIN') }
+  end
+
+  describe '#library_name' do
+    subject { self_checkout_status.library_name }
+
+    it { is_expected.to eq(nil) }
+  end
+
+  describe '#supported_messages' do
+    subject { self_checkout_status.supported_messages }
+
+    it { is_expected.to eq('YYYNYYYYNNNNNYYN') }
+  end
+
+  describe '#screen_message' do
+    subject { self_checkout_status.screen_message }
+
+    it { is_expected.to eq(nil) }
+  end
+
+  describe '#print_line' do
+    subject { self_checkout_status.print_line }
+
+    it { is_expected.to eq(nil) }
+  end
+end


### PR DESCRIPTION
This adds support for the Self Checkout Status message (99). It also adds better error handling around blank and nil responses from the SIP server.