### PR TITLE
Add support for custom fields

### DIFF
--- a/lib/sip2/responses/base_response.rb
+++ b/lib/sip2/responses/base_response.rb
@@ -39,6 +39,19 @@ module Sip2
         )
       end
 
+      # Given a two letter code, return the value of that custom field.
+      #
+      # ex: response.custom_field('PT')
+      # => "2020"
+      #
+      # @param code [String] - The SIP2 code to return
+      # @return [String] - Returns a string if the code was found
+      # @return [nil] - Returns nil if no value was found
+      #
+      def custom_field(code)
+        parse_text(raw_response, code)
+      end
+
       private
 
       # Retrieve a text string from the response.

--- a/spec/responses/patron_information_spec.rb
+++ b/spec/responses/patron_information_spec.rb
@@ -8,6 +8,9 @@ describe Sip2::Responses::PatronInformation do
   let(:raw_response_invalid_patron) { '64              00020101014    120549000000000003        0002AOMAIN|AAJSMITH|AESmith, John|BLN|AU111111|AY0AZE0E8' }
   let(:raw_response_incorrect_barcode) { '64              00020101014    120549000000000003        0002AOMAIN|AAJSMITH|AESmith, John|BLY|CQN|AU111111|AY0AZE0E8' }
   let(:invalid_response) { '' }
+  let(:response_with_pt_field) do
+    %[64              00120230601    111226000000000008000100000000AODoylestown|AAD1111111|AETest,Account|BLY|CQY|BHUSD|BV0.50|CC19.50|AKL9158574 The pie an 06/05/2023|AKL9716975 Cook's ill 06/21/2023|AKL1288933 The perfec 06/21/2023|AKL9585820 The rye ba 06/21/2023|AKL1245165 Half baked 06/21/2023|AKL6588364 The savory 06/21/2023|AKL1115080 Pasta Gran 06/21/2023|AKL1288987 Milk Stree 06/21/2023|AV 592770 $0.50 "Overdue book materia" Chirri & Chirra|FB0.50|PEI380|PT2020|AY8AZ821F]
+  end
   # rubocop:enable LineLength
 
   describe '#patron_valid?' do
@@ -60,6 +63,18 @@ describe Sip2::Responses::PatronInformation do
     context 'blank response' do
       let(:response) { 'FOO|AQ|BAR' }
       it { is_expected.to eq '' }
+    end
+  end
+
+  describe 'custom_field' do
+    subject{ patron_information.custom_field('PT') }
+
+    let(:response) { response_with_pt_field }
+    it { is_expected.to eq('2020') }
+
+    context 'given a response without the custom field' do
+      let(:response) { raw_response_valid_patron }
+      it { is_expected.to be_nil}
     end
   end
 end


### PR DESCRIPTION
This allows us to read non-standard fields such as the PT or PR from the Patron Information response